### PR TITLE
Fixed desync in blog post publish date

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -10,6 +10,7 @@ export function formatDate(date: string) {
     day: "numeric",
     month: "long",
     year: "numeric",
+    timezone: "UTC"
   });
 }
 


### PR DESCRIPTION
# Issue

There is an inconsistency in the date displayed on blog posts between the preview cards and the posts themselves. Notice the dates in the cards from top to bottom: Dec 24, Nov 15, Oct 20, and Sep 13.

<img width="725" height="765" alt="image" src="https://github.com/user-attachments/assets/54690cf8-9426-4ead-93d6-76f71e4f21d1" />

The dates on the posts themselves are consistently 1 day afterwards (or rather the preview date is always 1 day before the actual publish date).

<img width="713" height="452" alt="image" src="https://github.com/user-attachments/assets/0645e488-4fb3-4af7-94c5-e68b5060958e" />
<img width="685" height="392" alt="image" src="https://github.com/user-attachments/assets/ff6aca71-447e-4443-9efb-4dc9426184da" />
<img width="672" height="424" alt="image" src="https://github.com/user-attachments/assets/8ec943b3-b113-493f-bbad-cf4f56497e65" />
<img width="706" height="385" alt="image" src="https://github.com/user-attachments/assets/74b1bb89-19a7-4776-9c26-5360d1d2720c" />

# Cause

In `src/lib/utils.formatDate()`, there is a call to `Date.toLocaleDateString()`. There are some quirks of Node's implementation of `Date.toLocaleDateString()` that I don't fully understand, but it seems to vary depending on the environment, including more than the system time zone ([read more here](https://www.peterbe.com/plog/be-careful-with-date.tolocaledatestring)).

# The Fix

Pass `timezone: "UTC"` to the `options` object in  `Date.toLocaleDateString()`. This will apply the same time zone at the top level to all dates displayed on the site (which all call `utils.formatDate()`).